### PR TITLE
Cope without Bio.Alphabet for Biopython 1.78 onwards

### DIFF
--- a/deepbgc/util.py
+++ b/deepbgc/util.py
@@ -15,12 +15,6 @@ import gzip
 
 import six
 from Bio import SeqIO
-try:
-    from Bio.Alphabet import SingleLetterAlphabet, generic_dna
-except ImportError:
-    # Removed in Biopython 1.78
-    SingleLetterAlphabet = None
-    generic_dna = None
 from appdirs import user_data_dir
 try:
     from urllib.request import urlretrieve
@@ -515,16 +509,10 @@ def fix_duplicate_cds(record):
 
 def fix_dna_alphabet(record):
     """Explicitly label a SeqRecord as DNA (e.g. for GenBank output)."""
-    # Following will only happen on a legacy Biopython:
-    if generic_dna:
-        if type(record.seq.alphabet) == SingleLetterAlphabet:
-            logging.warning('Updating record alphabet to generic_dna')
-        record.seq.alphabet = generic_dna
-    # Following should be harmless on older Biopython,
-    # but is required on Biopython 1.78 onwards for GenBank:
     if "DNA" != record.annotations.get("molecule_type", ""):
         logging.warning('Updating record molecule type to DNA')
     record.annotations['molecule_type'] = 'DNA'
+
 
 def read_compatible_csv(path):
     sep = '\t' if path.endswith('.tsv') else ','

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from io import open
 
 install_requires = [
     'argparse',
-    'biopython==1.76', # support for structured comments from version 1.70, removed Alphabet in version 1.78
+    'biopython>=1.70', # support for structured comments from version 1.70
     'scikit-learn==0.21.3', # sklearn with random forest compatibility
     'pandas==0.24.1',
     'numpy==1.16.1',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from io import open
 
 install_requires = [
     'argparse',
-    'biopython>=1.70', # support for structured comments from version 1.70
+    'biopython>=1.78', # Bio.Alphabet was removed then
     'scikit-learn==0.21.3', # sklearn with random forest compatibility
     'pandas==0.24.1',
     'numpy==1.16.1',

--- a/test/unit/output/test_unit_writers.py
+++ b/test/unit/output/test_unit_writers.py
@@ -13,7 +13,11 @@ import collections
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.SeqFeature import SeqFeature, FeatureLocation
-from Bio.Alphabet import generic_dna
+try:
+    from Bio.Alphabet import generic_dna
+except ImportError:
+    # Removed in Biopython 1.78
+    generic_dna = None
 import os
 import pytest
 
@@ -45,7 +49,13 @@ WRITERS = [
 @pytest.fixture
 def processed_record(detector_name='deepbgc', detector_label='deepbgc', score_threshold=0.5):
     comment_key = util.format_detector_meta_key(detector_label)
-    record = SeqRecord(Seq('ACTGCTCGACTGATT', alphabet=generic_dna))
+    if generic_dna:
+        # Legacy mode
+        record = SeqRecord(Seq('ACTGCTCGACTGATT', alphabet=generic_dna))
+    else:
+        # Use this on Biopython 1.78 onwards
+        record = SeqRecord(Seq('ACTGCTCGACTGATT'))
+    record.annotations['molecule_type'] = 'DNA'
     record.annotations['structured_comment'] = collections.OrderedDict()
     record.annotations['structured_comment'][comment_key] = collections.OrderedDict(
         name=detector_name,

--- a/test/unit/output/test_unit_writers.py
+++ b/test/unit/output/test_unit_writers.py
@@ -13,11 +13,6 @@ import collections
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.SeqFeature import SeqFeature, FeatureLocation
-try:
-    from Bio.Alphabet import generic_dna
-except ImportError:
-    # Removed in Biopython 1.78
-    generic_dna = None
 import os
 import pytest
 
@@ -49,12 +44,7 @@ WRITERS = [
 @pytest.fixture
 def processed_record(detector_name='deepbgc', detector_label='deepbgc', score_threshold=0.5):
     comment_key = util.format_detector_meta_key(detector_label)
-    if generic_dna:
-        # Legacy mode
-        record = SeqRecord(Seq('ACTGCTCGACTGATT', alphabet=generic_dna))
-    else:
-        # Use this on Biopython 1.78 onwards
-        record = SeqRecord(Seq('ACTGCTCGACTGATT'))
+    record = SeqRecord(Seq('ACTGCTCGACTGATT'))
     record.annotations['molecule_type'] = 'DNA'
     record.annotations['structured_comment'] = collections.OrderedDict()
     record.annotations['structured_comment'][comment_key] = collections.OrderedDict(


### PR DESCRIPTION
I have tried running the tests with ``pytest`` but don't have all the dependencies setup. I would suggest you test this locally with biopython 1.76, and then update biopython and retest.

The code changes proposed here would be simpler if you would be happy to require Biopython 1.78 onwards.
